### PR TITLE
sim: Fix use of deprecated Yosys command

### DIFF
--- a/chipflow_lib/platforms/sim.py
+++ b/chipflow_lib/platforms/sim.py
@@ -94,7 +94,7 @@ class SimPlatform:
                 else:
                     # FIXME: use -defer (workaround for YosysHQ/yosys#4059)
                     print(f"read_verilog {extra_filename}", file=yosys_file)
-            print("read_ilang sim_soc.il", file=yosys_file)
+            print("read_rtlil sim_soc.il", file=yosys_file)
             print("hierarchy -top sim_top", file=yosys_file)
             # FIXME: use the default -O6 (workaround for YosysHQ/yosys#4227)
             print("write_cxxrtl -O4 -header sim_soc.cc", file=yosys_file)


### PR DESCRIPTION
`read_ilang` was an alias for `read_rtlil` that has now been removed