### PR TITLE
do not allow redirects when submitting

### DIFF
--- a/chipflow_lib/steps/silicon.py
+++ b/chipflow_lib/steps/silicon.py
@@ -184,7 +184,9 @@ class SiliconStep:
             files={
                 "rtlil": open(rtlil_path, "rb"),
                 "config": json.dumps(config),
-            })
+            },
+            allow_redirects=False
+            )
 
         # Parse response body
         try:


### PR DESCRIPTION
This will disable redirects when doing chipflow silicon submit which will prevent unauthed submit requests redirecting to github login.