### PR TITLE
feat(submit): pack design + pins.lock + manifest into a single bundle.zip

### DIFF
--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -3,15 +3,17 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import inspect
+import io
 import json
 import logging
 import os
 import requests
-import shutil
 import subprocess
 import sys
 import urllib3
 import webbrowser
+import zipfile
+from pathlib import Path
 from pprint import pformat
 
 
@@ -28,6 +30,37 @@ from ..auth import get_api_key, AuthenticationError
 
 
 logger = logging.getLogger(__name__)
+
+
+def _build_bundle_zip(rtlil_path, config: str) -> bytes:
+    """Pack the submission into a single zip with a manifest.
+
+    Layout::
+
+        manifest.json
+        <rtlil filename>     # e.g. "top.il", taken from rtlil_path
+        pins.lock            # the pinlock JSON
+
+    The manifest is the only contract: consumers locate the rtlil and
+    config payloads via ``manifest["rtlil"]`` and ``manifest["config"]``.
+    Future additions (e.g. macro folders) extend the manifest without
+    changing this function's signature on the wire.
+    """
+    rtlil_arc = Path(rtlil_path).name
+    config_arc = "pins.lock"
+    manifest = {
+        "version": "1",
+        "rtlil": rtlil_arc,
+        "config": config_arc,
+    }
+    manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", manifest_bytes)
+        zf.writestr(config_arc, config)
+        zf.write(str(rtlil_path), arcname=rtlil_arc)
+    return buf.getvalue()
 
 
 def halo_logging(closure):
@@ -181,16 +214,14 @@ class SiliconStep:
             pinlock = load_pinlock()
             config = pinlock.model_dump_json(indent=2)
 
+            bundle_bytes = _build_bundle_zip(rtlil_path, config)
+
             if args.dry_run:
                 sp.succeed(f"✅ Design `{data['projectId']}:{data['name']}` ready for submission to ChipFlow cloud!")
                 logger.debug(f"data=\n{json.dumps(data, indent=2)}")
                 logger.debug(f"files['config']=\n{config}")
-                shutil.copyfile(rtlil_path, 'rtlil')
-                with open("rtlil", 'w') as f:
-                    json.dump(data, f)
-                with open("config", 'w') as f:
-                    f.write(config)
-                sp.info("Compiled design and configuration can be found in in `rtlil` and `config`")
+                Path("bundle.zip").write_bytes(bundle_bytes)
+                sp.info("Compiled submission written to `bundle.zip` (manifest.json + rtlil + pins.lock)")
                 return
 
             def network_err(e):
@@ -217,8 +248,7 @@ class SiliconStep:
                     auth=("", self._chipflow_api_key),
                     data=data,
                     files={
-                        "rtlil": open(rtlil_path, "rb"),
-                        "config": config,
+                        "bundle": ("bundle.zip", bundle_bytes, "application/zip"),
                     },
                     allow_redirects=False
                     )

--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -46,17 +46,20 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
     use it to identify the design without re-parsing the pinlock.
 
     The manifest is the only contract: consumers locate the rtlil and
-    pinlock payloads via ``manifest["rtlil"]`` and ``manifest["pins_lock"]``.
-    Future additions (e.g. macro folders) extend the manifest without
-    changing this function's signature on the wire.
+    pinlock payloads via ``manifest["rtlil_file"]`` and
+    ``manifest["pins_lock_file"]``. Keys naming a file inside the
+    archive carry a ``_file`` suffix so they're distinguishable from
+    plain value keys (``version``, ``project``). Future additions (e.g.
+    macro folders) extend the manifest without changing this function's
+    signature on the wire.
     """
     rtlil_arc = Path(rtlil_path).name
     pins_lock_arc = "pins.lock"
     manifest = {
         "version": "1",
         "project": project_name,
-        "rtlil": rtlil_arc,
-        "pins_lock": pins_lock_arc,
+        "rtlil_file": rtlil_arc,
+        "pins_lock_file": pins_lock_arc,
     }
     manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
 

--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -32,7 +32,9 @@ from ..auth import get_api_key, AuthenticationError
 logger = logging.getLogger(__name__)
 
 
-def _build_bundle_zip(rtlil_path, config: str, project_name: str, process: str) -> bytes:
+def _build_bundle_zip(
+    rtlil_path, config: str, project_name: str, process: str, package: str
+) -> bytes:
     """Pack the submission into a single zip with a manifest.
 
     Layout::
@@ -41,22 +43,22 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str, process: str) 
         <rtlil filename>     # e.g. "top.il", taken from rtlil_path
         pins.lock            # the pinlock JSON
 
-    ``project_name`` is the chipflow.toml ``[chipflow] project_name`` value;
-    ``process`` is the chipflow.toml ``[chipflow.silicon] process`` value
-    (e.g. "sky130", "gf180"). Consumers (logs, dashboards, the backend's
-    working directory naming and PDK selection) use these to identify
-    and route the design without re-parsing the pinlock.
+    ``project_name`` / ``process`` / ``package`` come from chipflow.toml
+    (``[chipflow] project_name``, ``[chipflow.silicon] process``,
+    ``[chipflow.silicon] package``). Consumers (logs, dashboards, the
+    backend's working directory naming and PDK / package selection) use
+    these to identify and route the design without re-parsing the pinlock.
 
     The manifest is the only contract: consumers locate the design and
     pinlock payloads via ``manifest["design_file"]`` and
     ``manifest["pins_lock_file"]``. Keys naming a file inside the
     archive carry a ``_file`` suffix so they're distinguishable from
-    plain value keys (``version``, ``project``, ``process``); the value
-    is a zip-relative path. ``design_file`` is named in terms of role
-    rather than format so the same key can carry rtlil today, or another
-    intermediate (Verilog, FIRRTL) tomorrow, without renaming. Future
-    additions (e.g. macro folders) extend the manifest without
-    changing this function's signature on the wire.
+    plain value keys (``version``, ``project``, ``process``,
+    ``package``); the value is a zip-relative path. ``design_file`` is
+    named in terms of role rather than format so the same key can carry
+    rtlil today, or another intermediate (Verilog, FIRRTL) tomorrow,
+    without renaming. Future additions (e.g. macro folders) extend the
+    manifest without changing this function's signature on the wire.
     """
     design_arc = Path(rtlil_path).name
     pins_lock_arc = "pins.lock"
@@ -64,6 +66,7 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str, process: str) 
         "version": "1",
         "project": project_name,
         "process": process,
+        "package": package,
         "design_file": design_arc,
         "pins_lock_file": pins_lock_arc,
     }
@@ -231,7 +234,8 @@ class SiliconStep:
             bundle_bytes = _build_bundle_zip(
                 rtlil_path, config,
                 self.config.chipflow.project_name,
-                self.config.chipflow.silicon.process.value)
+                self.config.chipflow.silicon.process.value,
+                self.config.chipflow.silicon.package)
 
             if args.dry_run:
                 sp.succeed(f"✅ Design `{data['projectId']}:{data['name']}` ready for submission to ChipFlow cloud!")

--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -43,27 +43,27 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
 
     ``project_name`` is the chipflow.toml ``[chipflow] project_name`` value;
     consumers (logs, dashboards, the backend's working directory naming)
-    use it to identify the design without re-parsing the config.
+    use it to identify the design without re-parsing the pinlock.
 
     The manifest is the only contract: consumers locate the rtlil and
-    config payloads via ``manifest["rtlil"]`` and ``manifest["config"]``.
+    pinlock payloads via ``manifest["rtlil"]`` and ``manifest["pins_lock"]``.
     Future additions (e.g. macro folders) extend the manifest without
     changing this function's signature on the wire.
     """
     rtlil_arc = Path(rtlil_path).name
-    config_arc = "pins.lock"
+    pins_lock_arc = "pins.lock"
     manifest = {
         "version": "1",
         "project": project_name,
         "rtlil": rtlil_arc,
-        "config": config_arc,
+        "pins_lock": pins_lock_arc,
     }
     manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
 
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("manifest.json", manifest_bytes)
-        zf.writestr(config_arc, config)
+        zf.writestr(pins_lock_arc, config)
         zf.write(str(rtlil_path), arcname=rtlil_arc)
     return buf.getvalue()
 

--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -32,7 +32,7 @@ from ..auth import get_api_key, AuthenticationError
 logger = logging.getLogger(__name__)
 
 
-def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
+def _build_bundle_zip(rtlil_path, config: str, project_name: str, process: str) -> bytes:
     """Pack the submission into a single zip with a manifest.
 
     Layout::
@@ -42,16 +42,18 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
         pins.lock            # the pinlock JSON
 
     ``project_name`` is the chipflow.toml ``[chipflow] project_name`` value;
-    consumers (logs, dashboards, the backend's working directory naming)
-    use it to identify the design without re-parsing the pinlock.
+    ``process`` is the chipflow.toml ``[chipflow.silicon] process`` value
+    (e.g. "sky130", "gf180"). Consumers (logs, dashboards, the backend's
+    working directory naming and PDK selection) use these to identify
+    and route the design without re-parsing the pinlock.
 
     The manifest is the only contract: consumers locate the design and
     pinlock payloads via ``manifest["design_file"]`` and
     ``manifest["pins_lock_file"]``. Keys naming a file inside the
     archive carry a ``_file`` suffix so they're distinguishable from
-    plain value keys (``version``, ``project``); the value is a
-    zip-relative path. ``design_file`` is named in terms of role rather
-    than format so the same key can carry rtlil today, or another
+    plain value keys (``version``, ``project``, ``process``); the value
+    is a zip-relative path. ``design_file`` is named in terms of role
+    rather than format so the same key can carry rtlil today, or another
     intermediate (Verilog, FIRRTL) tomorrow, without renaming. Future
     additions (e.g. macro folders) extend the manifest without
     changing this function's signature on the wire.
@@ -61,6 +63,7 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
     manifest = {
         "version": "1",
         "project": project_name,
+        "process": process,
         "design_file": design_arc,
         "pins_lock_file": pins_lock_arc,
     }
@@ -226,7 +229,9 @@ class SiliconStep:
             config = pinlock.model_dump_json(indent=2)
 
             bundle_bytes = _build_bundle_zip(
-                rtlil_path, config, self.config.chipflow.project_name)
+                rtlil_path, config,
+                self.config.chipflow.project_name,
+                self.config.chipflow.silicon.process.value)
 
             if args.dry_run:
                 sp.succeed(f"✅ Design `{data['projectId']}:{data['name']}` ready for submission to ChipFlow cloud!")

--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -226,8 +226,9 @@ class SiliconStep:
                 sp.succeed(f"✅ Design `{data['projectId']}:{data['name']}` ready for submission to ChipFlow cloud!")
                 logger.debug(f"data=\n{json.dumps(data, indent=2)}")
                 logger.debug(f"files['config']=\n{config}")
-                Path("bundle.zip").write_bytes(bundle_bytes)
-                sp.info("Compiled submission written to `bundle.zip` (manifest.json + rtlil + pins.lock)")
+                bundle_path = Path(rtlil_path).parent / "bundle.zip"
+                bundle_path.write_bytes(bundle_bytes)
+                sp.info(f"Compiled submission written to `{bundle_path}` (manifest.json + rtlil + pins.lock)")
                 return
 
             def network_err(e):

--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -45,20 +45,23 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
     consumers (logs, dashboards, the backend's working directory naming)
     use it to identify the design without re-parsing the pinlock.
 
-    The manifest is the only contract: consumers locate the rtlil and
-    pinlock payloads via ``manifest["rtlil_file"]`` and
+    The manifest is the only contract: consumers locate the design and
+    pinlock payloads via ``manifest["design_file"]`` and
     ``manifest["pins_lock_file"]``. Keys naming a file inside the
     archive carry a ``_file`` suffix so they're distinguishable from
-    plain value keys (``version``, ``project``). Future additions (e.g.
-    macro folders) extend the manifest without changing this function's
-    signature on the wire.
+    plain value keys (``version``, ``project``); the value is a
+    zip-relative path. ``design_file`` is named in terms of role rather
+    than format so the same key can carry rtlil today, or another
+    intermediate (Verilog, FIRRTL) tomorrow, without renaming. Future
+    additions (e.g. macro folders) extend the manifest without
+    changing this function's signature on the wire.
     """
-    rtlil_arc = Path(rtlil_path).name
+    design_arc = Path(rtlil_path).name
     pins_lock_arc = "pins.lock"
     manifest = {
         "version": "1",
         "project": project_name,
-        "rtlil_file": rtlil_arc,
+        "design_file": design_arc,
         "pins_lock_file": pins_lock_arc,
     }
     manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
@@ -67,7 +70,7 @@ def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
     with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("manifest.json", manifest_bytes)
         zf.writestr(pins_lock_arc, config)
-        zf.write(str(rtlil_path), arcname=rtlil_arc)
+        zf.write(str(rtlil_path), arcname=design_arc)
     return buf.getvalue()
 
 

--- a/chipflow/platform/silicon_step.py
+++ b/chipflow/platform/silicon_step.py
@@ -32,7 +32,7 @@ from ..auth import get_api_key, AuthenticationError
 logger = logging.getLogger(__name__)
 
 
-def _build_bundle_zip(rtlil_path, config: str) -> bytes:
+def _build_bundle_zip(rtlil_path, config: str, project_name: str) -> bytes:
     """Pack the submission into a single zip with a manifest.
 
     Layout::
@@ -40,6 +40,10 @@ def _build_bundle_zip(rtlil_path, config: str) -> bytes:
         manifest.json
         <rtlil filename>     # e.g. "top.il", taken from rtlil_path
         pins.lock            # the pinlock JSON
+
+    ``project_name`` is the chipflow.toml ``[chipflow] project_name`` value;
+    consumers (logs, dashboards, the backend's working directory naming)
+    use it to identify the design without re-parsing the config.
 
     The manifest is the only contract: consumers locate the rtlil and
     config payloads via ``manifest["rtlil"]`` and ``manifest["config"]``.
@@ -50,6 +54,7 @@ def _build_bundle_zip(rtlil_path, config: str) -> bytes:
     config_arc = "pins.lock"
     manifest = {
         "version": "1",
+        "project": project_name,
         "rtlil": rtlil_arc,
         "config": config_arc,
     }
@@ -214,7 +219,8 @@ class SiliconStep:
             pinlock = load_pinlock()
             config = pinlock.model_dump_json(indent=2)
 
-            bundle_bytes = _build_bundle_zip(rtlil_path, config)
+            bundle_bytes = _build_bundle_zip(
+                rtlil_path, config, self.config.chipflow.project_name)
 
             if args.dry_run:
                 sp.succeed(f"✅ Design `{data['projectId']}:{data['name']}` ready for submission to ChipFlow cloud!")

--- a/tests/test_silicon_submit.py
+++ b/tests/test_silicon_submit.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+import io
+import json
 import unittest
+import zipfile
 from unittest import mock
 from argparse import Namespace
 from pathlib import Path
 import tempfile
 import os
 
-from chipflow.platform.silicon_step import SiliconStep
+from chipflow.platform.silicon_step import SiliconStep, _build_bundle_zip
 
 
 class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
@@ -54,9 +57,9 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
             step.platform._ports = {}
 
             # Mock the submit method dependencies
-            with mock.patch.object(step, 'prepare', return_value='/tmp/test.il'):
-                with mock.patch('builtins.open', mock.mock_open(read_data=b'')):
-                    with mock.patch('chipflow.platform.silicon_step.requests.post') as mock_post:
+            with mock.patch.object(step, 'prepare', return_value='/tmp/test.il'), \
+                    mock.patch('chipflow.platform.silicon_step._build_bundle_zip', return_value=b'fake-bundle'):
+                with mock.patch('chipflow.platform.silicon_step.requests.post') as mock_post:
                         # Mock successful submission
                         mock_response = mock.MagicMock()
                         mock_response.status_code = 200
@@ -103,9 +106,9 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
             step.platform._ports = {}
 
             # Mock the submit method dependencies
-            with mock.patch.object(step, 'prepare', return_value='/tmp/test.il'):
-                with mock.patch('builtins.open', mock.mock_open(read_data=b'')):
-                    with mock.patch('chipflow.platform.silicon_step.requests.post') as mock_post:
+            with mock.patch.object(step, 'prepare', return_value='/tmp/test.il'), \
+                    mock.patch('chipflow.platform.silicon_step._build_bundle_zip', return_value=b'fake-bundle'):
+                with mock.patch('chipflow.platform.silicon_step.requests.post') as mock_post:
                         # Mock successful submission
                         mock_response = mock.MagicMock()
                         mock_response.status_code = 200
@@ -150,9 +153,9 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
             step.platform._ports = {}
 
             # Mock the submit method dependencies
-            with mock.patch.object(step, 'prepare', return_value='/tmp/test.il'):
-                with mock.patch('builtins.open', mock.mock_open(read_data=b'')):
-                    with mock.patch('chipflow.platform.silicon_step.requests.post') as mock_post:
+            with mock.patch.object(step, 'prepare', return_value='/tmp/test.il'), \
+                    mock.patch('chipflow.platform.silicon_step._build_bundle_zip', return_value=b'fake-bundle'):
+                with mock.patch('chipflow.platform.silicon_step.requests.post') as mock_post:
                         # Mock successful submission
                         mock_response = mock.MagicMock()
                         mock_response.status_code = 200
@@ -173,6 +176,79 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
                                 mock_input.assert_not_called()
                                 # Verify webbrowser.open was NOT called
                                 mock_webbrowser.assert_not_called()
+
+
+class TestBuildBundleZip(unittest.TestCase):
+    """Tests for the _build_bundle_zip helper."""
+
+    def test_manifest_and_layout(self):
+        with tempfile.TemporaryDirectory() as td:
+            rtlil_path = Path(td) / "top.il"
+            rtlil_path.write_text("module top(); endmodule\n")
+            config = '{"pins": []}'
+
+            blob = _build_bundle_zip(rtlil_path, config)
+
+            with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+                names = set(zf.namelist())
+                self.assertEqual(names, {"manifest.json", "top.il", "pins.lock"})
+
+                manifest = json.loads(zf.read("manifest.json"))
+                self.assertEqual(manifest["version"], "1")
+                self.assertEqual(manifest["rtlil"], "top.il")
+                self.assertEqual(manifest["config"], "pins.lock")
+
+                self.assertEqual(zf.read("top.il").decode(), "module top(); endmodule\n")
+                self.assertEqual(zf.read("pins.lock").decode(), config)
+
+    def test_uses_real_rtlil_filename(self):
+        """Bundle preserves the source rtlil filename (not a fixed string)."""
+        with tempfile.TemporaryDirectory() as td:
+            rtlil_path = Path(td) / "weird_name.rtlil"
+            rtlil_path.write_text("x")
+            blob = _build_bundle_zip(rtlil_path, "{}")
+            with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+                self.assertIn("weird_name.rtlil", zf.namelist())
+                manifest = json.loads(zf.read("manifest.json"))
+                self.assertEqual(manifest["rtlil"], "weird_name.rtlil")
+
+
+class TestSiliconSubmitBundlePost(unittest.TestCase):
+    """The submit() path posts a single 'bundle' multipart part."""
+
+    @mock.patch('chipflow.packaging.load_pinlock')
+    @mock.patch('chipflow.platform.silicon_step.subprocess.check_output')
+    def test_submit_sends_single_bundle_part(self, mock_subprocess, mock_load_pinlock):
+        mock_subprocess.return_value = 'test123\n'
+        mock_pinlock = mock.MagicMock()
+        mock_pinlock.model_dump_json.return_value = '{}'
+        mock_load_pinlock.return_value = mock_pinlock
+
+        with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
+            config = mock.MagicMock()
+            config.chipflow.silicon = True
+            config.chipflow.project_name = 'test_project'
+            step = SiliconStep(config)
+            step.platform._ports = {}
+
+            with mock.patch.object(step, 'prepare', return_value='/tmp/test.il'), \
+                    mock.patch('chipflow.platform.silicon_step._build_bundle_zip',
+                               return_value=b'fake-bundle-bytes'), \
+                    mock.patch('chipflow.platform.silicon_step.requests.post') as mock_post, \
+                    mock.patch('chipflow.platform.silicon_step.get_api_key', return_value='k'), \
+                    mock.patch('chipflow.platform.silicon_step.exit'), \
+                    mock.patch('sys.stdout.isatty', return_value=False):
+                mock_post.return_value = mock.MagicMock(
+                    status_code=200, json=lambda: {'build_id': 'b1'})
+                step._chipflow_api_key = 'k'
+                step.submit('/tmp/test.il', Namespace(dry_run=False, wait=False))
+
+            files = mock_post.call_args.kwargs["files"]
+            self.assertEqual(set(files.keys()), {"bundle"})
+            filename, payload, content_type = files["bundle"]
+            self.assertEqual(filename, "bundle.zip")
+            self.assertEqual(payload, b'fake-bundle-bytes')
+            self.assertEqual(content_type, "application/zip")
 
 
 if __name__ == "__main__":

--- a/tests/test_silicon_submit.py
+++ b/tests/test_silicon_submit.py
@@ -187,7 +187,7 @@ class TestBuildBundleZip(unittest.TestCase):
             rtlil_path.write_text("module top(); endmodule\n")
             config = '{"pins": []}'
 
-            blob = _build_bundle_zip(rtlil_path, config)
+            blob = _build_bundle_zip(rtlil_path, config, "my_project")
 
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 names = set(zf.namelist())
@@ -195,6 +195,7 @@ class TestBuildBundleZip(unittest.TestCase):
 
                 manifest = json.loads(zf.read("manifest.json"))
                 self.assertEqual(manifest["version"], "1")
+                self.assertEqual(manifest["project"], "my_project")
                 self.assertEqual(manifest["rtlil"], "top.il")
                 self.assertEqual(manifest["config"], "pins.lock")
 
@@ -206,7 +207,7 @@ class TestBuildBundleZip(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             rtlil_path = Path(td) / "weird_name.rtlil"
             rtlil_path.write_text("x")
-            blob = _build_bundle_zip(rtlil_path, "{}")
+            blob = _build_bundle_zip(rtlil_path, "{}", "p")
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 self.assertIn("weird_name.rtlil", zf.namelist())
                 manifest = json.loads(zf.read("manifest.json"))

--- a/tests/test_silicon_submit.py
+++ b/tests/test_silicon_submit.py
@@ -50,7 +50,7 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
         # Create a mock SiliconStep instance
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
-            config.chipflow.silicon = True
+            config.chipflow.silicon.process.value = 'sky130'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step._build_url = "https://build.chipflow.com/build/test123"
@@ -99,7 +99,7 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
         # Create a mock SiliconStep instance
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
-            config.chipflow.silicon = True
+            config.chipflow.silicon.process.value = 'sky130'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step._build_url = "https://build.chipflow.com/build/test123"
@@ -146,7 +146,7 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
         # Create a mock SiliconStep instance
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
-            config.chipflow.silicon = True
+            config.chipflow.silicon.process.value = 'sky130'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step._build_url = "https://build.chipflow.com/build/test123"
@@ -187,7 +187,7 @@ class TestBuildBundleZip(unittest.TestCase):
             rtlil_path.write_text("module top(); endmodule\n")
             config = '{"pins": []}'
 
-            blob = _build_bundle_zip(rtlil_path, config, "my_project")
+            blob = _build_bundle_zip(rtlil_path, config, "my_project", "sky130")
 
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 names = set(zf.namelist())
@@ -196,6 +196,7 @@ class TestBuildBundleZip(unittest.TestCase):
                 manifest = json.loads(zf.read("manifest.json"))
                 self.assertEqual(manifest["version"], "1")
                 self.assertEqual(manifest["project"], "my_project")
+                self.assertEqual(manifest["process"], "sky130")
                 self.assertEqual(manifest["design_file"], "top.il")
                 self.assertEqual(manifest["pins_lock_file"], "pins.lock")
 
@@ -207,7 +208,7 @@ class TestBuildBundleZip(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             rtlil_path = Path(td) / "weird_name.rtlil"
             rtlil_path.write_text("x")
-            blob = _build_bundle_zip(rtlil_path, "{}", "p")
+            blob = _build_bundle_zip(rtlil_path, "{}", "p", "sky130")
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 self.assertIn("weird_name.rtlil", zf.namelist())
                 manifest = json.loads(zf.read("manifest.json"))
@@ -227,7 +228,7 @@ class TestSiliconSubmitBundlePost(unittest.TestCase):
 
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
-            config.chipflow.silicon = True
+            config.chipflow.silicon.process.value = 'sky130'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step.platform._ports = {}

--- a/tests/test_silicon_submit.py
+++ b/tests/test_silicon_submit.py
@@ -197,7 +197,7 @@ class TestBuildBundleZip(unittest.TestCase):
                 self.assertEqual(manifest["version"], "1")
                 self.assertEqual(manifest["project"], "my_project")
                 self.assertEqual(manifest["rtlil"], "top.il")
-                self.assertEqual(manifest["config"], "pins.lock")
+                self.assertEqual(manifest["pins_lock"], "pins.lock")
 
                 self.assertEqual(zf.read("top.il").decode(), "module top(); endmodule\n")
                 self.assertEqual(zf.read("pins.lock").decode(), config)

--- a/tests/test_silicon_submit.py
+++ b/tests/test_silicon_submit.py
@@ -51,6 +51,7 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
             config.chipflow.silicon.process.value = 'sky130'
+            config.chipflow.silicon.package = 'cf20'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step._build_url = "https://build.chipflow.com/build/test123"
@@ -100,6 +101,7 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
             config.chipflow.silicon.process.value = 'sky130'
+            config.chipflow.silicon.package = 'cf20'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step._build_url = "https://build.chipflow.com/build/test123"
@@ -147,6 +149,7 @@ class TestSiliconSubmitBrowserPrompt(unittest.TestCase):
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
             config.chipflow.silicon.process.value = 'sky130'
+            config.chipflow.silicon.package = 'cf20'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step._build_url = "https://build.chipflow.com/build/test123"
@@ -187,7 +190,7 @@ class TestBuildBundleZip(unittest.TestCase):
             rtlil_path.write_text("module top(); endmodule\n")
             config = '{"pins": []}'
 
-            blob = _build_bundle_zip(rtlil_path, config, "my_project", "sky130")
+            blob = _build_bundle_zip(rtlil_path, config, "my_project", "sky130", "cf20")
 
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 names = set(zf.namelist())
@@ -197,6 +200,7 @@ class TestBuildBundleZip(unittest.TestCase):
                 self.assertEqual(manifest["version"], "1")
                 self.assertEqual(manifest["project"], "my_project")
                 self.assertEqual(manifest["process"], "sky130")
+                self.assertEqual(manifest["package"], "cf20")
                 self.assertEqual(manifest["design_file"], "top.il")
                 self.assertEqual(manifest["pins_lock_file"], "pins.lock")
 
@@ -208,7 +212,7 @@ class TestBuildBundleZip(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             rtlil_path = Path(td) / "weird_name.rtlil"
             rtlil_path.write_text("x")
-            blob = _build_bundle_zip(rtlil_path, "{}", "p", "sky130")
+            blob = _build_bundle_zip(rtlil_path, "{}", "p", "sky130", "cf20")
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 self.assertIn("weird_name.rtlil", zf.namelist())
                 manifest = json.loads(zf.read("manifest.json"))
@@ -229,6 +233,7 @@ class TestSiliconSubmitBundlePost(unittest.TestCase):
         with mock.patch('chipflow.platform.silicon_step.SiliconPlatform'):
             config = mock.MagicMock()
             config.chipflow.silicon.process.value = 'sky130'
+            config.chipflow.silicon.package = 'cf20'
             config.chipflow.project_name = 'test_project'
             step = SiliconStep(config)
             step.platform._ports = {}

--- a/tests/test_silicon_submit.py
+++ b/tests/test_silicon_submit.py
@@ -196,7 +196,7 @@ class TestBuildBundleZip(unittest.TestCase):
                 manifest = json.loads(zf.read("manifest.json"))
                 self.assertEqual(manifest["version"], "1")
                 self.assertEqual(manifest["project"], "my_project")
-                self.assertEqual(manifest["rtlil_file"], "top.il")
+                self.assertEqual(manifest["design_file"], "top.il")
                 self.assertEqual(manifest["pins_lock_file"], "pins.lock")
 
                 self.assertEqual(zf.read("top.il").decode(), "module top(); endmodule\n")
@@ -211,7 +211,7 @@ class TestBuildBundleZip(unittest.TestCase):
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 self.assertIn("weird_name.rtlil", zf.namelist())
                 manifest = json.loads(zf.read("manifest.json"))
-                self.assertEqual(manifest["rtlil_file"], "weird_name.rtlil")
+                self.assertEqual(manifest["design_file"], "weird_name.rtlil")
 
 
 class TestSiliconSubmitBundlePost(unittest.TestCase):

--- a/tests/test_silicon_submit.py
+++ b/tests/test_silicon_submit.py
@@ -196,8 +196,8 @@ class TestBuildBundleZip(unittest.TestCase):
                 manifest = json.loads(zf.read("manifest.json"))
                 self.assertEqual(manifest["version"], "1")
                 self.assertEqual(manifest["project"], "my_project")
-                self.assertEqual(manifest["rtlil"], "top.il")
-                self.assertEqual(manifest["pins_lock"], "pins.lock")
+                self.assertEqual(manifest["rtlil_file"], "top.il")
+                self.assertEqual(manifest["pins_lock_file"], "pins.lock")
 
                 self.assertEqual(zf.read("top.il").decode(), "module top(); endmodule\n")
                 self.assertEqual(zf.read("pins.lock").decode(), config)
@@ -211,7 +211,7 @@ class TestBuildBundleZip(unittest.TestCase):
             with zipfile.ZipFile(io.BytesIO(blob)) as zf:
                 self.assertIn("weird_name.rtlil", zf.namelist())
                 manifest = json.loads(zf.read("manifest.json"))
-                self.assertEqual(manifest["rtlil"], "weird_name.rtlil")
+                self.assertEqual(manifest["rtlil_file"], "weird_name.rtlil")
 
 
 class TestSiliconSubmitBundlePost(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Replaces the two-part `rtlil` + `config` multipart submit with a single `bundle` part carrying `bundle.zip`. Inside the zip:
  - `manifest.json` — the only contract; consumers locate payloads through it.
  - `<design basename>` — e.g. `top.il`, taken from `rtlil_path`.
  - `pins.lock` — the pinlock JSON (`pinlock.model_dump_json`).
- Manifest fields: `version: "1"`, `project` (from `[chipflow] project_name`), `process` and `package` (from `[chipflow.silicon]`), `design_file` and `pins_lock_file` (zip-relative paths). Keys whose value names a file inside the archive carry a `_file` suffix.
- Dry-run writes `bundle.zip` next to the rtlil (`Path(rtlil_path).parent`), so it lands inside amaranth's build folder rather than the user's CWD.

## Why a single bundle

One uniform shape on the wire, on disk, and in storage. The manifest is the indirection point — adding macro folders later (rebased PR #163) is purely additive: new `_file` keys + new folders, no wire-format change. Reproducibility win too: the bundle is a single self-describing artifact you can replay months later.

## Files

- `chipflow/platform/silicon_step.py` — `+_build_bundle_zip` helper; rewritten dry-run + submit blocks.
- `tests/test_silicon_submit.py` — kept the 3 browser-prompt tests (mocking the helper); added `TestBuildBundleZip` (manifest shape, real-filename preservation) and `TestSiliconSubmitBundlePost` (asserts the multipart payload is `{"bundle": ("bundle.zip", bytes, "application/zip")}`).

## Cross-repo PRs

- chipflow-api (v1, production): ChipFlow/chipflow-api#20
- chipflow-backend: ChipFlow/chipflow-backend#302
- chipflow-api-v2 (parked, draft): ChipFlow/chipflow-api-v2#2

## End-to-end validation

Real submission against `chipflow-api-staging` with backend image `branch-feat-bundle-zip-submit`: build `0620ceda-c829-4142-94c3-42f8abe9c518` ran the full IHP SG13G2 synth + P&R flow to `status="completed"`.

## Test plan

- [x] `pytest --ignore=tests/test_cli_integration.py` — 65 passed, 10 skipped (pre-existing CLI-integration skips).
- [x] `ruff check` clean on `chipflow/` and `tests/`.
- [x] End-to-end against the staging API + bundle-aware backend, completed.