### PR TITLE
fix(auth): suggest 'gh auth refresh -s user:email' when token lacks the scope

### DIFF
--- a/chipflow/auth.py
+++ b/chipflow/auth.py
@@ -135,14 +135,27 @@ def authenticate_with_github_token(api_origin: str, interactive: bool = True):
                 logger.debug(f"Invalid JSON response on success: {e}, body: {response.text[:200]}")
                 return None
         else:
+            error_code = ""
             try:
-                error_msg = response.json().get("error_description", "Unknown error")
+                body = response.json()
+                error_code = body.get("error", "")
+                error_msg = body.get("error_description", "Unknown error")
             except ValueError:
                 error_msg = f"HTTP {response.status_code}"
                 logger.debug(f"Non-JSON error response: {response.text[:200]}")
 
             if interactive:
                 print(f"⚠️  GitHub token authentication failed: {error_msg}")
+                if error_code == "missing_email":
+                    # The server fetched the gh token but couldn't read the
+                    # user's email — the token is missing the user:email
+                    # scope. Tell the user the exact command to fix it,
+                    # otherwise they fall through to device flow with no clue.
+                    print(
+                        "\n💡 Your `gh` CLI token is missing the `user:email` scope.\n"
+                        "   Run this once and retry:\n"
+                        "       gh auth refresh -s user:email"
+                    )
             logger.debug(f"GitHub token auth failed: {response.status_code} - {error_msg}")
             return None
 


### PR DESCRIPTION
## Background

When the chipflow API's `/auth/github-token` endpoint returns 400 with `{"error": "missing_email"}`, it means the gh CLI's token is missing the `user:email` scope, so the server can't fetch a verified email and refuses to issue an API key.

The current code just prints the generic _"GitHub token authentication failed: ..."_ message and silently falls through to device flow. In non-interactive contexts that flow then expires after a few minutes, leaving the user with no idea what was wrong or how to fix it.

This was the actual confusion that took ~30 minutes to diagnose during the bundle.zip rollout today. Past `chipflow silicon submit` invocations had worked fine because that gh token had the scope; a later `gh auth refresh` (or VS Code re-auth) silently dropped it.

## Change

Detect the specific `missing_email` error code in `authenticate_with_github_token` and print:

```
💡 Your `gh` CLI token is missing the `user:email` scope.
   Run this once and retry:
       gh auth refresh -s user:email
```

Generic-error path unchanged.

## Test plan

- [x] Manual: confirmed today that `gh auth refresh -s user:email` fixes the situation; this just makes that finding actionable for future users.