### PR TITLE
feat(process): add GF180MCU process variant

### DIFF
--- a/chipflow/config/models.py
+++ b/chipflow/config/models.py
@@ -15,8 +15,10 @@ class Process(Enum):
     """
     #: Skywater foundry open-source 130nm process
     SKY130 = "sky130"
-    #: GlobalFoundries open-source 130nm process
+    #: GlobalFoundries open-source 130nm process (c4m-gf180 variant)
     GF180 = "gf180"
+    #: GlobalFoundries open-source 180nm MCU PDK
+    GF180MCU = "gf180mcu"
     #: Pragmatic Semiconductor FlexIC process (old)
     HELVELLYN2 = "helvellyn2"
     #: GlobalFoundries 130nm BCD process

--- a/chipflow/platform/silicon.py
+++ b/chipflow/platform/silicon.py
@@ -342,7 +342,7 @@ def port_for_process(p: Process):
     match p:
         case Process.SKY130:
             return Sky130Port
-        case Process.GF180 | Process.HELVELLYN2 | Process.GF130BCD | Process.IHP_SG13G2:
+        case Process.GF180 | Process.GF180MCU | Process.HELVELLYN2 | Process.GF130BCD | Process.IHP_SG13G2:
             return SiliconPlatformPort
 
 


### PR DESCRIPTION
## Summary
Add \`Process.GF180MCU\` = \`\"gf180mcu\"\` for the GlobalFoundries open-source 180nm MCU PDK, distinct from the existing \`\"gf180\"\` (c4m-gf180 variant). Both share the GF 180nm node but use different cell libraries and IO conventions; on the backend side they're served by separate techno plugins (\`techno-c4m-gf180\` vs \`techno-gf180mcu\`).

## Changes
- \`chipflow/config/models.py\` — add \`GF180MCU = \"gf180mcu\"\` to the \`Process\` enum, clarify the \`GF180\` docstring to flag the variant distinction.
- \`chipflow/platform/silicon.py\` — route \`GF180MCU\` through the same default branch of \`port_for_process\` that the other non-Sky130 processes use (\`SiliconPlatformPort\`).

## Why now
chipflow-backend has a [techno-gf180mcu plugin](https://github.com/ChipFlow/chipflow-backend/tree/main/packages/techno-gf180mcu) coming in shortly. Without this enum entry, designs configured with \`process = \"gf180mcu\"\` in their chipflow.toml are rejected by chipflow-lib's pydantic validation before even reaching the backend.

## Test plan
- [ ] Lint / type-check
- [ ] Existing tests pass (this is purely additive — no behavior change for existing processes)
- [ ] End-to-end: a chipflow-test-socs design with \`process = \"gf180mcu\"\` passes \`chipflow pin lock\` and produces a manifest that the chipflow-backend gf180mcu PR accepts